### PR TITLE
Fix wrong trajectory after timewarp/loading in FAR model.

### DIFF
--- a/src/AeroDynamicModels/AeroDynamicModel.cs
+++ b/src/AeroDynamicModels/AeroDynamicModel.cs
@@ -100,7 +100,7 @@ namespace Trajectories
             if (!Trajectories.IsVesselAttached || body_ != body)
                 return false;
 
-            if (Settings.AutoUpdateAeroDynamicModel)
+            if (Settings.AutoUpdateAeroDynamicModel && IsReady())
             {
                 double newRefDrag = ComputeReferenceDrag();
                 if (referenceDrag == 0)
@@ -251,5 +251,10 @@ namespace Trajectories
         /// See PackForces
         /// </summary>
         public virtual Vector3d UnpackForces(Vector2d packedForces, double altitudeAboveSea, double velocity) => new Vector3d(packedForces.x, packedForces.y, 0.0);
+
+        /// <summary>
+        /// Returns true when the aerodynamic model is ready to compute forces.
+        /// </summary>
+        public abstract bool IsReady();
     }
 }

--- a/src/AeroDynamicModels/AeroDynamicModelFactory.cs
+++ b/src/AeroDynamicModels/AeroDynamicModelFactory.cs
@@ -37,10 +37,20 @@ namespace Trajectories
                     {
                         case "FerramAerospaceResearch":
                             var FARAPIType = loadedAssembly.assembly.GetType("FerramAerospaceResearch.FARAPI");
+                            var FARAPI_CalculateVesselAeroForces = FARAPIType.GetMethodEx(
+                                "CalculateVesselAeroForces",
+                                BindingFlags.Public | BindingFlags.Static,
+                                new Type[] { typeof(Vessel), typeof(Vector3).MakeByRefType(), typeof(Vector3).MakeByRefType(), typeof(Vector3), typeof(double) }
+                            );
 
-                                var FARAPI_CalculateVesselAeroForces = FARAPIType.GetMethodEx("CalculateVesselAeroForces", BindingFlags.Public | BindingFlags.Static, new Type[] { typeof(Vessel), typeof(Vector3).MakeByRefType(), typeof(Vector3).MakeByRefType(), typeof(Vector3), typeof(double) });
+                            var FARVesselAeroType = loadedAssembly.assembly.GetType("FerramAerospaceResearch.FARAeroComponents.FARVesselAero");
+                            var FARVesselAero_HasValidVoxelizationCurrently = FARVesselAeroType.GetMethodEx(
+                                "HasValidVoxelizationCurrently",
+                                BindingFlags.Public | BindingFlags.Instance,
+                                new Type[] { }
+                            );
 
-                            return new FARModel(body, FARAPI_CalculateVesselAeroForces);
+                            return new FARModel(body, FARAPI_CalculateVesselAeroForces, FARVesselAero_HasValidVoxelizationCurrently);
 
                         //case "MyModAssembly":
                         // implement here your atmo mod detection

--- a/src/AeroDynamicModels/Models/StockModel.cs
+++ b/src/AeroDynamicModels/Models/StockModel.cs
@@ -25,11 +25,11 @@ using UnityEngine;
 
 namespace Trajectories
 {
-    class StockModel: AeroDynamicModel
+    class StockModel : AeroDynamicModel
     {
         public override string AeroDynamicModelName { get { return Localizer.Format("#autoLOC_Trajectories_Stock"); } }
 
-        public StockModel(CelestialBody body) : base( body) { }
+        public StockModel(CelestialBody body) : base(body) { }
 
         protected override Vector3d ComputeForces_Model(Vector3d airVelocity, double altitude)
         {
@@ -53,5 +53,9 @@ namespace Trajectories
 
             return new Vector3d(packedForces.x * scale, packedForces.y * scale, 0.0d);
         }
+
+        // Stock model seems to be always ready to compute forces. If this turns out to be false,
+        // implement this function.
+        public override bool IsReady() => true;
     }
 }

--- a/src/Display/AppLauncherButton.cs
+++ b/src/Display/AppLauncherButton.cs
@@ -1,5 +1,5 @@
 /*
-  Copyright© (c) 2017-2020 S.Gray, (aka PiezPiedPy).
+  CopyrightÂ© (c) 2017-2020 S.Gray, (aka PiezPiedPy).
 
   This file is part of Trajectories.
   Trajectories is available under the terms of GPL-3.0-or-later.

--- a/src/Predictor/Trajectory.cs
+++ b/src/Predictor/Trajectory.cs
@@ -360,39 +360,42 @@ namespace Trajectories
                     aerodynamicModel_.UpdateVesselMass();
                 }
 
-                // if there is no ongoing partial computation, start a new one
-                if (partialComputation_ == null)
+                if (aerodynamicModel_.IsReady())
                 {
-                    //total_time = Util.Clocks;
+                    // if there is no ongoing partial computation, start a new one
+                    if (partialComputation_ == null)
+                    {
+                        //total_time = Util.Clocks;
 
-                    // restart the public buffers
-                    patchesBackBuffer_.Clear();
-                    maxAccelBackBuffer_ = 0;
+                        // restart the public buffers
+                        patchesBackBuffer_.Clear();
+                        maxAccelBackBuffer_ = 0;
 
-                    // Create enumerator for Trajectory increment calculator
-                    partialComputation_ = ComputeTrajectoryIncrement().GetEnumerator();
-                }
+                        // Create enumerator for Trajectory increment calculator
+                        partialComputation_ = ComputeTrajectoryIncrement().GetEnumerator();
+                    }
 
-                // we are finished when there are no more partial computations to be done
-                bool finished = !partialComputation_.MoveNext();
+                    // we are finished when there are no more partial computations to be done
+                    bool finished = !partialComputation_.MoveNext();
 
-                // when calculation is finished,
-                if (finished)
-                {
-                    // swap the buffers for the patches and the maximum acceleration,
-                    // "publishing" the results
-                    List<Patch> tmp = Patches;
-                    Patches = patchesBackBuffer_;
-                    patchesBackBuffer_ = tmp;
+                    // when calculation is finished,
+                    if (finished)
+                    {
+                        // swap the buffers for the patches and the maximum acceleration,
+                        // "publishing" the results
+                        List<Patch> tmp = Patches;
+                        Patches = patchesBackBuffer_;
+                        patchesBackBuffer_ = tmp;
 
-                    MaxAccel = maxAccelBackBuffer_;
+                        MaxAccel = maxAccelBackBuffer_;
 
-                    // Reset partial computation
-                    partialComputation_.Dispose();
-                    partialComputation_ = null;
+                        // Reset partial computation
+                        partialComputation_.Dispose();
+                        partialComputation_ = null;
 
-                    // how long did the whole calculation take?
-                    //total_time = Util.ElapsedMilliseconds(total_time);
+                        // how long did the whole calculation take?
+                        //total_time = Util.ElapsedMilliseconds(total_time);
+                    }
                 }
 
                 // how long did the calculation in this frame take?


### PR DESCRIPTION
Fixes #186

**Before:**
When exiting time warp or loading a save, aerodynamic forces were often computed before the FAR aerodynamic model was ready. The FAR model is ready when the active vessel is not packed and its FARVesselAero component reports that it has a valid voxelization. Computing forces before the model was ready resulted in zero forces, that were then entered into the cache. This caused the cached values to be invalid and the trajectory was wrong. Pressing the update button helped because it forced a cache rebuild.

**After:**
Forces are now only computed when the FAR aerodynamic model is ready. The trajectory is correct after time warp or loading a save. This change does not affect the stock model. More technical info in the commit messages.