### PR TITLE
Fix swapping left and right clicks toggles between four states

### DIFF
--- a/src/Display/AppLauncherButton.cs
+++ b/src/Display/AppLauncherButton.cs
@@ -1,5 +1,5 @@
 /*
-  Copyright© (c) 2017-2020 S.Gray, (aka PiezPiedPy).
+  CopyrightÂ© (c) 2017-2020 S.Gray, (aka PiezPiedPy).
 
   This file is part of Trajectories.
   Trajectories is available under the terms of GPL-3.0-or-later.

--- a/src/Display/AppLauncherButton.cs
+++ b/src/Display/AppLauncherButton.cs
@@ -34,7 +34,7 @@ namespace Trajectories
         internal const string MODID = "Trajectories_NS";
         internal const string MODNAME = "Trajectories";
 
-        internal const  string TRAJ_TEXTURE_PATH =  "Trajectories/PluginData/Textures/";
+        internal const string TRAJ_TEXTURE_PATH = "Trajectories/PluginData/Textures/";
 
 #if false
         private class BlizzyToolbarButtonVisibility : IVisibility
@@ -114,10 +114,7 @@ namespace Trajectories
                     TRAJ_TEXTURE_PATH + "icon-blizzy",
                     MODNAME
                 );
-                if (!Settings.SwapLeftRightClicks)
-                    toolbarControl.AddLeftRightClickCallbacks(OnLeftToggle, OnRightToggle);
-                else
-                    toolbarControl.AddLeftRightClickCallbacks(OnRightToggle, OnLeftToggle);
+                toolbarControl.AddLeftRightClickCallbacks(OnLeftToggle, OnRightToggle);
             }
 #if false
             if (ToolbarManager.ToolbarAvailable && Settings.UseBlizzyToolbar)
@@ -192,19 +189,33 @@ namespace Trajectories
 
         internal static void OnLeftToggle()
         {
+            if (Settings.SwapLeftRightClicks)
+                OnMainGUIToggle();
+            else
+                OnTrajectoryToggle();
+        }
+        internal static void OnRightToggle()
+        {
+            if (Settings.SwapLeftRightClicks)
+                OnTrajectoryToggle();
+            else
+                OnMainGUIToggle();
+        }
+        internal static void OnTrajectoryToggle()
+        {
             // check that we have patched conics. If not, apologize to the user and return.
             if (!Util.IsPatchedConicsAvailable)
             {
                 ScreenMessages.PostScreenMessage(Localizer.Format("#autoLOC_Trajectories_ConicsErr"));
                 Settings.DisplayTrajectories = false;
-                return; 
+                return;
             }
 
             Settings.DisplayTrajectories = !Settings.DisplayTrajectories;
-            MainGUI. OnButtonClick_DisplayTrajectories(Settings.DisplayTrajectories);
+            MainGUI.OnButtonClick_DisplayTrajectories(Settings.DisplayTrajectories);
 
         }
-        internal static void OnRightToggle()
+        internal static void OnMainGUIToggle()
         {
             Settings.MainGUIEnabled = !Settings.MainGUIEnabled;
         }

--- a/src/Display/MainGUI.cs
+++ b/src/Display/MainGUI.cs
@@ -695,7 +695,7 @@ namespace Trajectories
         /// <summary>
         /// Creates the event listeners for the text input boxes
         /// </summary>
-        private static void SetTextInputBoxEvents(bool add=true)
+        private static void SetTextInputBoxEvents(bool add = true)
         {
             keyboard_lockout_action = new UnityAction<string>(KeyboardLockout);
             keyboard_unlock_action = new UnityAction<string>(KeyboardUnlock);
@@ -898,14 +898,7 @@ namespace Trajectories
         }
 #endif
 
-        private static void OnButtonClick_SwapLeftRightClicks(bool inState)
-        {
-            if (Settings.SwapLeftRightClicks)
-                AppLauncherButton.toolbarControl.AddLeftRightClickCallbacks(AppLauncherButton.OnLeftToggle, AppLauncherButton.OnRightToggle);
-            else
-                AppLauncherButton.toolbarControl.AddLeftRightClickCallbacks(AppLauncherButton.OnRightToggle, AppLauncherButton.OnLeftToggle);
-            Settings.SwapLeftRightClicks = inState;
-        }
+        private static void OnButtonClick_SwapLeftRightClicks(bool inState) => Settings.SwapLeftRightClicks = inState;
 
         private static void OnButtonClick_Prograde()
         {


### PR DESCRIPTION
Fixes #3 on the Trajectories side.

**Before:**
A new toolbar button callback was added every time the "swap left/right clicks" checkbox was toggled. These callbacks were interfering with each other.

**After:**
Toolbar button callbacks are now added only once. Inside the callbacks, the left and right click actions are selected based on the `Settings.SwapLeftRightClicks` value.